### PR TITLE
Introduce rebuild carry path

### DIFF
--- a/playbook-all.yml
+++ b/playbook-all.yml
@@ -39,6 +39,11 @@
     - role: base-ubuntu-docker
 
   tasks:
+
+    - name: debug ansible_hostname
+      debug:
+        msg: "{{ ansible_hostname }}"
+
     - name: ping servers
       ping:
 
@@ -62,7 +67,6 @@
     - name: restore carry paths after rebuild
       include_role:
         name: rebuild-carry-path-restore
-      when: rebuilt
 
     - name: deploy docker-compose project
       include_role:

--- a/playbook-all.yml
+++ b/playbook-all.yml
@@ -33,7 +33,7 @@
         timeout: 30
 
 - name: provision / deploy on servers
-  hosts: all:!localhost
+  hosts: all:!localhost:!temp
 
   roles:
     - role: base-ubuntu-docker

--- a/playbook-all.yml
+++ b/playbook-all.yml
@@ -39,11 +39,6 @@
     - role: base-ubuntu-docker
 
   tasks:
-
-    - name: debug ansible_hostname
-      debug:
-        msg: "{{ ansible_hostname }}"
-
     - name: ping servers
       ping:
 

--- a/playbook-all.yml
+++ b/playbook-all.yml
@@ -38,7 +38,6 @@
   roles:
     - role: base-ubuntu-docker
 
-
   tasks:
     - name: ping servers
       ping:
@@ -59,6 +58,11 @@
     - name: ensure right user is logged in
       fail: "wrong user is used! should: {{ ansible_user }} | is: {{ whoami.stdout }}"
       when: whoami.stdout != ansible_user
+
+    - name: restore carry paths after rebuild
+      include_role:
+        name: rebuild-carry-path-restore
+      when: rebuilt
 
     - name: deploy docker-compose project
       include_role:

--- a/roles/hetzner/tasks/configuration.yml
+++ b/roles/hetzner/tasks/configuration.yml
@@ -4,6 +4,7 @@
     hcloud_server: { "hcloud_server_info": [] }
     hcloud_server_labels: {}
     ansible_user: "root"
+    rebuilt: false
 
 - name: Gather hcloud server infos
   hcloud_server_info:
@@ -54,4 +55,5 @@
 - name: get ansible user from rebuild
   set_fact:
     ansible_user: root
+    rebuilt: true
   when: hcloud_server_state == "rebuild"

--- a/roles/hetzner/tasks/configuration.yml
+++ b/roles/hetzner/tasks/configuration.yml
@@ -4,7 +4,12 @@
     hcloud_server: { "hcloud_server_info": [] }
     hcloud_server_labels: {}
     ansible_user: "root"
-    rebuilt: false
+    rebuild_carry_paths: []
+
+- name: set if rebuild carry paths are available
+  set_fact:
+    rebuild_carry_paths: "{{ config.server.rebuild_carry_paths }}"
+  when: config.server.rebuild_carry_paths is defined and config.server.rebuild_carry_paths | length > 0
 
 - name: Gather hcloud server infos
   hcloud_server_info:
@@ -35,25 +40,11 @@
   set_fact:
     hcloud_server_labels: "{{ hcloud_server_labels | combine(config.server.labels) }}"
 
-- name: do not rebuild server as default
+- name: check create mode ( present / rebuild )
   set_fact:
-    hcloud_server_state: present
-
-- name: do rebuild
-  set_fact:
-    hcloud_server_state: rebuild
-  when: config.server.rebuild is defined and config.server.rebuild == true
-
-- name: check environment if rebuild needed
-  set_fact:
-    hcloud_server_state: "{{ lookup('env', config.server.rebuild | replace('$', '') | replace('{', '') | replace('}', '')) | bool | ternary('rebuild', 'present') }}"
-  when: >
-    config.server.rebuild is defined
-    and (config.server.rebuild is string)
-    and config.server.rebuild.startswith("$")
+    hcloud_server_state: "{{ rebuild | bool | ternary('rebuild', 'present') }}"
 
 - name: get ansible user from rebuild
   set_fact:
     ansible_user: root
-    rebuilt: true
-  when: hcloud_server_state == "rebuild"
+  when: rebuild

--- a/roles/hetzner/tasks/inventory.yml
+++ b/roles/hetzner/tasks/inventory.yml
@@ -5,4 +5,5 @@
     ansible_ssh_host: "{{ hcloud_server.ipv4_address }}"
     ansible_user: "{{ ansible_user }}"
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+    rebuilt: "{{ rebuilt }}"
   args: "{{ config.vars }}"

--- a/roles/hetzner/tasks/inventory.yml
+++ b/roles/hetzner/tasks/inventory.yml
@@ -5,5 +5,6 @@
     ansible_ssh_host: "{{ hcloud_server.ipv4_address }}"
     ansible_user: "{{ ansible_user }}"
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
-    rebuilt: "{{ rebuilt }}"
+    rebuild: "{{ rebuild }}"
+    rebuild_carry_paths: "{{ rebuild_carry_paths }}"
   args: "{{ config.vars }}"

--- a/roles/rebuild-carry-path-backup/tasks/archive-transfer.yml
+++ b/roles/rebuild-carry-path-backup/tasks/archive-transfer.yml
@@ -1,0 +1,22 @@
+---
+- name: ensure target directory exist
+  file:
+    path: "/tmp/{{ config.name }}{{ carry_path }}"
+    state: directory
+  delegate_to: "temp-{{ hcloud_server.name }}"
+
+- name: archive rebuild carry path
+  archive:
+    path: "{{ carry_path }}"
+    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+    force_archive: true
+  become: yes
+  delegate_to: "temp-{{ hcloud_server.name }}"
+
+- name: backup rebuild carry path archive
+  fetch:
+    src: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+    flat: yes
+  become: yes
+  delegate_to: "temp-{{ hcloud_server.name }}"

--- a/roles/rebuild-carry-path-backup/tasks/archive-transfer.yml
+++ b/roles/rebuild-carry-path-backup/tasks/archive-transfer.yml
@@ -7,16 +7,16 @@
 
 - name: archive rebuild carry path
   archive:
-    path: "{{ carry_path }}"
-    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+    path: "{{ carry_path }}/*"
+    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.tar.gz"
     force_archive: true
   become: yes
   delegate_to: "temp-{{ hcloud_server.name }}"
 
 - name: backup rebuild carry path archive
   fetch:
-    src: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
-    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+    src: "/tmp/{{ config.name }}{{ carry_path }}/archive.tar.gz"
+    dest: "/tmp/{{ config.name }}{{ carry_path }}/archive.tar.gz"
     flat: yes
   become: yes
   delegate_to: "temp-{{ hcloud_server.name }}"

--- a/roles/rebuild-carry-path-backup/tasks/main.yml
+++ b/roles/rebuild-carry-path-backup/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- block:
+    - name: get hcloud api key from environment
+      set_fact:
+        hcloud_api_token: "{{ lookup('env', 'HCLOUD_API_TOKEN') }}"
+
+    - name: Gather hcloud server infos
+      hcloud_server_info:
+        api_token: "{{ hcloud_api_token }}"
+        name: "{{ config.name }}"
+      register: hcloud_server_info
+
+    - set_fact:
+        hcloud_server: "{{ hcloud_server_info.hcloud_server_info[0] }}"
+      when: not hcloud_server_info.failed
+
+    - file:
+        state: directory
+        path: "/tmp/{{ config.name }}/{{ carry_path }}"
+      with_items: "{{ config.server.rebuild_carry_paths }}"
+      loop_control:
+        loop_var: carry_path
+      when: hcloud_server is defined
+
+    - name: backup rebuild carry path
+      shell: "
+        rsync
+        --delay-updates
+        -F
+        --compress
+        --delete-after
+        --archive
+        --rsync-path='sudo rsync'
+        {{ hcloud_server.labels.ansible_user }}@{{ hcloud_server.ipv4_address }}:{{ carry_path }}
+        /tmp/{{ config.name }}/{{ carry_path }}"
+      with_items: "{{ config.server.rebuild_carry_paths }}"
+      loop_control:
+        loop_var: carry_path
+      when: hcloud_server is defined
+  when: config.server.rebuild_carry_paths is defined and config.server.rebuild_carry_paths | length > 0

--- a/roles/rebuild-carry-path-backup/tasks/main.yml
+++ b/roles/rebuild-carry-path-backup/tasks/main.yml
@@ -12,7 +12,7 @@
 
     - set_fact:
         hcloud_server: "{{ hcloud_server_info.hcloud_server_info[0] }}"
-      when: not hcloud_server_info.failed
+      when: not hcloud_server_info.failed and hcloud_server_info.hcloud_server_info | length > 0
 
     - name: add temp hcloud server to inventory
       add_host:
@@ -20,7 +20,9 @@
         ansible_ssh_host: "{{ hcloud_server.ipv4_address }}"
         ansible_user: "{{ hcloud_server.labels.ansible_user }}"
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
-        groupnames: "temp"
+        groups:
+          - "temp"
+      when: hcloud_server is defined
 
     - name: archive and transfer backup carry path
       include: tasks/archive-transfer.yml
@@ -28,8 +30,8 @@
       loop_control:
         loop_var: carry_path
       when: hcloud_server is defined
-  
+
   when: >
-    config.server.rebuild
+    rebuild
     and config.server.rebuild_carry_paths is defined
     and config.server.rebuild_carry_paths | length > 0

--- a/roles/rebuild-carry-path-backup/tasks/main.yml
+++ b/roles/rebuild-carry-path-backup/tasks/main.yml
@@ -14,27 +14,22 @@
         hcloud_server: "{{ hcloud_server_info.hcloud_server_info[0] }}"
       when: not hcloud_server_info.failed
 
-    - file:
-        state: directory
-        path: "/tmp/{{ config.name }}/{{ carry_path }}"
-      with_items: "{{ config.server.rebuild_carry_paths }}"
-      loop_control:
-        loop_var: carry_path
-      when: hcloud_server is defined
+    - name: add temp hcloud server to inventory
+      add_host:
+        hostname: "temp-{{ hcloud_server.name }}"
+        ansible_ssh_host: "{{ hcloud_server.ipv4_address }}"
+        ansible_user: "{{ hcloud_server.labels.ansible_user }}"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+        groupnames: "temp"
 
-    - name: backup rebuild carry path
-      shell: "
-        rsync
-        --delay-updates
-        -F
-        --compress
-        --delete-after
-        --archive
-        --rsync-path='sudo rsync'
-        {{ hcloud_server.labels.ansible_user }}@{{ hcloud_server.ipv4_address }}:{{ carry_path }}
-        /tmp/{{ config.name }}/{{ carry_path }}"
+    - name: archive and transfer backup carry path
+      include: tasks/archive-transfer.yml
       with_items: "{{ config.server.rebuild_carry_paths }}"
       loop_control:
         loop_var: carry_path
       when: hcloud_server is defined
-  when: config.server.rebuild_carry_paths is defined and config.server.rebuild_carry_paths | length > 0
+  
+  when: >
+    config.server.rebuild
+    and config.server.rebuild_carry_paths is defined
+    and config.server.rebuild_carry_paths | length > 0

--- a/roles/rebuild-carry-path-restore/tasks/main.yml
+++ b/roles/rebuild-carry-path-restore/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- block:
+    - name: restore rebuild carry path
+      shell: "
+        rsync
+        --delay-updates
+        -F
+        --compress
+        --delete-after
+        --archive
+        --rsync-path='sudo rsync'
+        /tmp/{{ config.name }}/{{ carry_path }}
+        {{ ansible_user }}@{{ ansible_ssh_host }}:{{ carry_path }}"
+      with_items: "{{ server.rebuild_carry_paths }}"
+      loop_control:
+        loop_var: carry_path
+      when: hcloud_server is defined
+  when: server.rebuild_carry_paths is defined and server.rebuild_carry_paths | length > 0
+  delegate_to: localhost

--- a/roles/rebuild-carry-path-restore/tasks/main.yml
+++ b/roles/rebuild-carry-path-restore/tasks/main.yml
@@ -5,4 +5,6 @@
       with_items: "{{ rebuild_carry_paths }}"
       loop_control:
         loop_var: carry_path
-  when: rebuild and rebuild_carry_paths | length > 0
+  when: >
+    rebuild
+    and rebuild_carry_paths | length > 0

--- a/roles/rebuild-carry-path-restore/tasks/main.yml
+++ b/roles/rebuild-carry-path-restore/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
 - block:
     - name: restore rebuild carry path
-      ansible.builtin.unarchive:
-        src: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
-        dest: "{{ carry_path }}"
-      become: yes
-      with_items: "{{ server.rebuild_carry_paths }}"
+      include: tasks/restore.yml
+      with_items: "{{ rebuild_carry_paths }}"
       loop_control:
         loop_var: carry_path
-  when: server.rebuild_carry_paths is defined and server.rebuild_carry_paths | length > 0
+  when: rebuild and rebuild_carry_paths | length > 0

--- a/roles/rebuild-carry-path-restore/tasks/main.yml
+++ b/roles/rebuild-carry-path-restore/tasks/main.yml
@@ -1,19 +1,11 @@
 ---
 - block:
     - name: restore rebuild carry path
-      shell: "
-        rsync
-        --delay-updates
-        -F
-        --compress
-        --delete-after
-        --archive
-        --rsync-path='sudo rsync'
-        /tmp/{{ config.name }}/{{ carry_path }}
-        {{ ansible_user }}@{{ ansible_ssh_host }}:{{ carry_path }}"
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ config.name }}{{ carry_path }}/archive.gz"
+        dest: "{{ carry_path }}"
+      become: yes
       with_items: "{{ server.rebuild_carry_paths }}"
       loop_control:
         loop_var: carry_path
-      when: hcloud_server is defined
   when: server.rebuild_carry_paths is defined and server.rebuild_carry_paths | length > 0
-  delegate_to: localhost

--- a/roles/rebuild-carry-path-restore/tasks/restore.yml
+++ b/roles/rebuild-carry-path-restore/tasks/restore.yml
@@ -1,8 +1,9 @@
 ---
 - name: check if carry path archive exists
   stat:
-    path: "/tmp/{{ ansible_hostname }}{{ carry_path }}/archive.gz"
+    path: "/tmp/{{ inventory_hostname }}{{ carry_path }}/archive.tar.gz"
   register: archive
+  delegate_to: localhost
 
 - name: ensure path restore path exists
   file:
@@ -13,7 +14,7 @@
 
 - name: restore 
   ansible.builtin.unarchive:
-    src: "/tmp/{{ ansible_hostname }}{{ carry_path }}/archive.gz"
+    src: "/tmp/{{ ansible_hostname }}{{ carry_path }}/archive.tar.gz"
     dest: "{{ carry_path }}"
   become: yes
   ignore_errors: yes # Empty archive files are not supported.

--- a/roles/rebuild-carry-path-restore/tasks/restore.yml
+++ b/roles/rebuild-carry-path-restore/tasks/restore.yml
@@ -1,0 +1,20 @@
+---
+- name: check if carry path archive exists
+  stat:
+    path: "/tmp/{{ ansible_hostname }}{{ carry_path }}/archive.gz"
+  register: archive
+
+- name: ensure path restore path exists
+  file:
+    path: "{{ carry_path }}"
+    state: directory
+  become: yes
+  when: archive.stat.exists
+
+- name: restore 
+  ansible.builtin.unarchive:
+    src: "/tmp/{{ ansible_hostname }}{{ carry_path }}/archive.gz"
+    dest: "{{ carry_path }}"
+  become: yes
+  ignore_errors: yes # Empty archive files are not supported.
+  when: archive.stat.exists

--- a/servers.yml.dist
+++ b/servers.yml.dist
@@ -12,6 +12,8 @@
       owner: wkloucek
       for: continuous-deployment
     rebuild: $REBUILD # / true / false
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.continuous.owncloud.works"

--- a/tasks/config_loop.yml
+++ b/tasks/config_loop.yml
@@ -1,5 +1,10 @@
 ---
 
+# TODO: handle server creation
+#- name: save rebuild carry path
+#  include_role:
+#    name: rebuild-carry-path-backup
+
 - name: create / check all servers
   include_role:
     name: hetzner

--- a/tasks/config_loop.yml
+++ b/tasks/config_loop.yml
@@ -1,9 +1,7 @@
 ---
-
-# TODO: handle server creation
-#- name: save rebuild carry path
-#  include_role:
-#    name: rebuild-carry-path-backup
+- name: save rebuild carry path
+  include_role:
+    name: rebuild-carry-path-backup
 
 - name: create / check all servers
   include_role:

--- a/tasks/config_loop.yml
+++ b/tasks/config_loop.yml
@@ -1,4 +1,25 @@
 ---
+
+- name: default is to do no rebuild
+  set_fact:
+    rebuild: false
+
+- name: do rebuild if activated
+  set_fact:
+    rebuild: true
+  when: config.server.rebuild is defined and config.server.rebuild == true
+
+- name: check environment if rebuild needed
+  set_fact:
+    rebuild: "{{ lookup('env', config.server.rebuild | replace('$', '') | replace('{', '') | replace('}', '')) | bool }}"
+  when: >
+    config.server.rebuild is defined
+    and (config.server.rebuild is string)
+    and config.server.rebuild.startswith("$")
+
+- debug:
+    msg: "{{ rebuild }}"
+
 - name: save rebuild carry path
   include_role:
     name: rebuild-carry-path-backup

--- a/tasks/config_loop.yml
+++ b/tasks/config_loop.yml
@@ -17,9 +17,6 @@
     and (config.server.rebuild is string)
     and config.server.rebuild.startswith("$")
 
-- debug:
-    msg: "{{ rebuild }}"
-
 - name: save rebuild carry path
   include_role:
     name: rebuild-carry-path-backup


### PR DESCRIPTION
This enables user to keep paths from a pruned server for the new server. Can be used for eg. LetsEncrypt certificates to prevent running into certificate issuing limits.