### PR TITLE
fix: fix #18 check that group "docker" is present

### DIFF
--- a/roles/base-ubuntu-docker/tasks/users.yml
+++ b/roles/base-ubuntu-docker/tasks/users.yml
@@ -2,7 +2,6 @@
 - name: Add docker group
   group:
     name: docker
-    gid: 115
     state: present
   become: yes
 


### PR DESCRIPTION
- check that group "docker" is present but ignore gid
- group checks that the group with name "docker" will be present, you
don't need a GID for that